### PR TITLE
Accessibility Fix – Modal Focus Order & Screen Reader Navigation

### DIFF
--- a/src/app/controller/tickets.controller.js
+++ b/src/app/controller/tickets.controller.js
@@ -89,6 +89,7 @@
     vm.searchLocation = $location.host(); // Set the current host
     vm.deviceDetect = deviceDetect; // Function to detect device
     vm.selectPass = selectPass; // Function to reset filters if select your pass is selected
+    vm.openAccordion = openAccordion; // Function to open accordion 
     // Set up the default Vars on page load, and so that they can be reset with 'reset filters' button
     function defaultVars() {
       vm.all = []; // Set results to blank array
@@ -1703,6 +1704,28 @@
       if (vm.passValue === '') {
         console.log('select pass');
         vm.clearFilter();
+      }
+    }
+
+    function openAccordion(event) {
+      const accordionBtn = event && event.currentTarget;
+      if (!accordionBtn) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const accordion = accordionBtn.closest ? accordionBtn.closest('.wmnds-accordion') : null;
+      if (!accordion) {
+        return;
+      }
+
+      if (accordion.classList.contains('wmnds-is--open')) {
+        accordion.classList.remove('wmnds-is--open');
+        accordionBtn.setAttribute('aria-expanded', 'false');
+      } else {
+        accordion.classList.add('wmnds-is--open');
+        accordionBtn.setAttribute('aria-expanded', 'true');
       }
     }
 

--- a/src/app/sass/assets/nwm-custom.scss
+++ b/src/app/sass/assets/nwm-custom.scss
@@ -3385,3 +3385,24 @@ a.icon-stylized-new:focus span:after {
 .sm__link--in {
     background-position: -242px -182px;
 }
+
+.wmnds-accordion {
+    button{
+        padding: 0px !important;
+        margin-bottom: 4px !important;
+        .wmnds-accordion__summary h4{
+            font-weight: lighter !important; 
+            font-size: 14px !important;           
+        }
+        svg{
+            width: 21px !important;
+            height: 21px !important;
+        }   
+    }
+
+    .wmnds-accordion__content{
+        border: 1px solid lightgray !important;
+        min-width: 265px;        
+    }
+
+}

--- a/src/app/tickets/views/shared/initial-search.html
+++ b/src/app/tickets/views/shared/initial-search.html
@@ -1,73 +1,37 @@
-<form
-  data-ng-submit="tickets.limit = 6;tickets.submit(tickets.postJSON);"
-  class="ticket-search"
-  name="tsearch"
-  novalidate
->
+<form data-ng-submit="tickets.limit = 6;tickets.submit(tickets.postJSON);" class="ticket-search" name="tsearch"
+  novalidate>
   <div class="grid-12">
-    <a
-      class="btn-link float--right"
-      href=""
-      data-ng-click="tickets.clearFilter();"
-      >Reset filters</a
-    >
+    <a class="btn-link float--right" href="" data-ng-click="tickets.clearFilter();">Reset filters</a>
   </div>
   <!-- Mode & Pass -->
   <div class="grid-5">
     <div class="fields new-transport-icons-blue">
       <label class="plain">Mode</label>
       <!--<label>Select All  <input type="checkbox" ng-model="isChecked" /></label>-->
-      <span
-        class="icon-stylized-new -bus -table-cell border-right--transparent"
-      >
-        <input
-          type="checkbox"
-          id="jpbus"
-          name="transportModeBus"
-          data-ng-model="tickets.postJSON.allowBus"
-          data-ng-false-value="false"
-          data-ng-true-value="true"
-          ng-disabled="tickets.postJSON.brand && tickets.postJSON.brand != ''"
-        />
+      <span class="icon-stylized-new -bus -table-cell border-right--transparent">
+        <input type="checkbox" id="jpbus" name="transportModeBus" data-ng-model="tickets.postJSON.allowBus"
+          data-ng-false-value="false" data-ng-true-value="true"
+          ng-disabled="tickets.postJSON.brand && tickets.postJSON.brand != ''" />
         <label for="jpbus">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            id="Layer_1"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
+          <svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" viewBox="0 0 24 24" aria-hidden="true">
             <style type="text/css">
               .st0 {
                 fill: none;
               }
             </style>
             <path class="st0" d="M0 0h24v24H0V0z" />
-            <path
-              id="XMLID_63_"
-              d="M16.5 6.9c0 0.3-0.3 0.6-0.6 0.6H8.1c-0.3 0-0.6-0.3-0.6-0.6V4.7c0-0.3 0.3-0.6 0.6-0.6h7.9c0.3 0 0.6 0.3 0.6 0.6V6.9zM9.7 9.4V9c0-0.2 0.2-0.3 0.3-0.3h3.8c0.2 0 0.3 0.2 0.3 0.3v0.5c0 0.2-0.2 0.3-0.3 0.3h-3.8C9.9 9.8 9.7 9.6 9.7 9.4M16.5 14.3c0 0.3-0.3 0.6-0.6 0.6H8.1c-0.3 0-0.6-0.3-0.6-0.6v-2.8c0-0.3 0.3-0.6 0.6-0.6h7.9c0.3 0 0.6 0.3 0.6 0.6V14.3zM15.7 17.6c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C16.5 17.2 16.1 17.6 15.7 17.6M8.3 17.6c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C9.2 17.2 8.8 17.6 8.3 17.6M16.5 3h-3.4 -2.2H7.5C6.9 3 6.4 3.5 6.4 4.1v14.1c0 0.6 0.5 1.1 1.1 1.1v1.4c0 0.2 0.2 0.3 0.3 0.3h1c0.2 0 0.3-0.2 0.3-0.3v-1.4h1.7 2.3 1.7v1.4c0 0.2 0.2 0.3 0.3 0.3h1c0.2 0 0.3-0.2 0.3-0.3v-1.4c0.6 0 1.1-0.5 1.1-1.1l0-14.1C17.6 3.5 17.1 3 16.5 3"
-            />
+            <path id="XMLID_63_"
+              d="M16.5 6.9c0 0.3-0.3 0.6-0.6 0.6H8.1c-0.3 0-0.6-0.3-0.6-0.6V4.7c0-0.3 0.3-0.6 0.6-0.6h7.9c0.3 0 0.6 0.3 0.6 0.6V6.9zM9.7 9.4V9c0-0.2 0.2-0.3 0.3-0.3h3.8c0.2 0 0.3 0.2 0.3 0.3v0.5c0 0.2-0.2 0.3-0.3 0.3h-3.8C9.9 9.8 9.7 9.6 9.7 9.4M16.5 14.3c0 0.3-0.3 0.6-0.6 0.6H8.1c-0.3 0-0.6-0.3-0.6-0.6v-2.8c0-0.3 0.3-0.6 0.6-0.6h7.9c0.3 0 0.6 0.3 0.6 0.6V14.3zM15.7 17.6c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C16.5 17.2 16.1 17.6 15.7 17.6M8.3 17.6c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C9.2 17.2 8.8 17.6 8.3 17.6M16.5 3h-3.4 -2.2H7.5C6.9 3 6.4 3.5 6.4 4.1v14.1c0 0.6 0.5 1.1 1.1 1.1v1.4c0 0.2 0.2 0.3 0.3 0.3h1c0.2 0 0.3-0.2 0.3-0.3v-1.4h1.7 2.3 1.7v1.4c0 0.2 0.2 0.3 0.3 0.3h1c0.2 0 0.3-0.2 0.3-0.3v-1.4c0.6 0 1.1-0.5 1.1-1.1l0-14.1C17.6 3.5 17.1 3 16.5 3" />
           </svg>
           <span>Bus</span>
         </label>
       </span>
-      <span
-        class="icon-stylized-new -train -table-cell border-left--transparent border-right--transparent"
-      >
-        <input
-          type="checkbox"
-          id="jptrain"
-          name="transportModeTrain"
-          data-ng-model="tickets.postJSON.allowTrain"
-          data-ng-false-value="false"
-          data-ng-true-value="true"
-          data-ng-change="tickets.clearStation();"
-          ng-disabled="tickets.postJSON.brand && tickets.postJSON.brand != ''"
-        />
+      <span class="icon-stylized-new -train -table-cell border-left--transparent border-right--transparent">
+        <input type="checkbox" id="jptrain" name="transportModeTrain" data-ng-model="tickets.postJSON.allowTrain"
+          data-ng-false-value="false" data-ng-true-value="true" data-ng-change="tickets.clearStation();"
+          ng-disabled="tickets.postJSON.brand && tickets.postJSON.brand != ''" />
         <label for="jptrain">
-          <svg xmlns="http://www.w3.org/2000/svg" 
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <style type="text/css">
               .st0 {
                 fill: none;
@@ -75,31 +39,19 @@
             </style>
             <path class="st0" d="M0 0h24v24H0V0z" />
             <path
-              d="M15.7 13.7c-0.5 0-0.8-0.4-0.8-0.8s0.4-0.8 0.8-0.8c0.5 0 0.8 0.4 0.8 0.8S16.1 13.7 15.7 13.7M12.6 8.1V4.7c0-0.3 0.3-0.6 0.6-0.6l0 0h0 0.6 0.9c0.8 0 1.6 0.8 1.6 1.7l0.1 1.1v0l0.1 1.1c0 0.3-0.2 0.6-0.5 0.6h-2.8C12.8 8.6 12.6 8.4 12.6 8.1M11.4 8.1c0 0.3-0.3 0.6-0.6 0.6H8.1c-0.3 0-0.5-0.3-0.5-0.6l0.1-1.1v0l0.1-1.1c0.1-0.9 0.8-1.7 1.6-1.7h0.9 0.6 0c0.3 0 0.6 0.3 0.6 0.6V8.1zM8.3 13.7c-0.5 0-0.8-0.4-0.8-0.8S7.9 12 8.3 12c0.5 0 0.8 0.4 0.8 0.8S8.8 13.7 8.3 13.7M17.9 13.1l-0.6-7.3C17.2 4.3 15.9 3 14.5 3S12 3 12 3s-1.1 0-2.5 0C8.1 3 6.8 4.3 6.7 5.8l-0.6 7.3c-0.1 1.5 1 2.8 2.6 2.8H12h0 3.4C16.9 15.9 18.1 14.7 17.9 13.1"
-            />
+              d="M15.7 13.7c-0.5 0-0.8-0.4-0.8-0.8s0.4-0.8 0.8-0.8c0.5 0 0.8 0.4 0.8 0.8S16.1 13.7 15.7 13.7M12.6 8.1V4.7c0-0.3 0.3-0.6 0.6-0.6l0 0h0 0.6 0.9c0.8 0 1.6 0.8 1.6 1.7l0.1 1.1v0l0.1 1.1c0 0.3-0.2 0.6-0.5 0.6h-2.8C12.8 8.6 12.6 8.4 12.6 8.1M11.4 8.1c0 0.3-0.3 0.6-0.6 0.6H8.1c-0.3 0-0.5-0.3-0.5-0.6l0.1-1.1v0l0.1-1.1c0.1-0.9 0.8-1.7 1.6-1.7h0.9 0.6 0c0.3 0 0.6 0.3 0.6 0.6V8.1zM8.3 13.7c-0.5 0-0.8-0.4-0.8-0.8S7.9 12 8.3 12c0.5 0 0.8 0.4 0.8 0.8S8.8 13.7 8.3 13.7M17.9 13.1l-0.6-7.3C17.2 4.3 15.9 3 14.5 3S12 3 12 3s-1.1 0-2.5 0C8.1 3 6.8 4.3 6.7 5.8l-0.6 7.3c-0.1 1.5 1 2.8 2.6 2.8H12h0 3.4C16.9 15.9 18.1 14.7 17.9 13.1" />
             <path
-              d="M8.8 18.8L9 17.6h6 0l0.2 1.1H8.8zM15.8 17.6l-0.5-1.1h-0.2H8.9 8.6l-0.5 1.1 -1.3 3.1c-0.1 0.2 0 0.3 0.2 0.3h1c0.2 0 0.4-0.2 0.4-0.3l0.1-0.8h6.8l0.1 0.8c0 0.2 0.2 0.3 0.4 0.3h1c0.2 0 0.3-0.1 0.2-0.3L15.8 17.6z"
-            />
+              d="M8.8 18.8L9 17.6h6 0l0.2 1.1H8.8zM15.8 17.6l-0.5-1.1h-0.2H8.9 8.6l-0.5 1.1 -1.3 3.1c-0.1 0.2 0 0.3 0.2 0.3h1c0.2 0 0.4-0.2 0.4-0.3l0.1-0.8h6.8l0.1 0.8c0 0.2 0.2 0.3 0.4 0.3h1c0.2 0 0.3-0.1 0.2-0.3L15.8 17.6z" />
           </svg>
           <span>Train</span>
         </label>
       </span>
-      <span
-        class="icon-stylized-new -tram -table-cell border-left--transparent"
-      >
-        <input
-          type="checkbox"
-          id="jptram"
-          name="transportModeTram"
-          data-ng-model="tickets.postJSON.allowMetro"
-          data-ng-false-value="false"
-          data-ng-true-value="true"
-          ng-disabled="tickets.postJSON.brand && tickets.postJSON.brand != ''"
-        />
+      <span class="icon-stylized-new -tram -table-cell border-left--transparent">
+        <input type="checkbox" id="jptram" name="transportModeTram" data-ng-model="tickets.postJSON.allowMetro"
+          data-ng-false-value="false" data-ng-true-value="true"
+          ng-disabled="tickets.postJSON.brand && tickets.postJSON.brand != ''" />
         <label for="jptram">
-          <svg xmlns="http://www.w3.org/2000/svg" 
-          viewBox="0 0 24 24"
-          aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <style type="text/css">
               .st0 {
                 fill: none;
@@ -107,14 +59,11 @@
             </style>
             <path class="st0" d="M0 0h24v24H0V0z" />
             <path
-              d="M15.7 15.4c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C16.5 15 16.1 15.4 15.7 15.4M12 12.6H8.2c-0.3 0-0.5-0.3-0.5-0.6L8 8.6C8 8 8.6 7.5 9.2 7.5H12h0 0 2.8C15.4 7.5 16 8 16 8.6l0.3 3.4c0 0.3-0.2 0.6-0.5 0.6H12zM8.3 15.4c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C9.2 15 8.8 15.4 8.3 15.4M10.9 5.1L12 4l1.1 1.1L12 6.3 10.9 5.1zM17.7 14.8l-0.5-6.2c-0.1-1.2-1.2-2.2-2.5-2.2h-1.5L14 5.5c0.2-0.2 0.2-0.5 0-0.7l-1.7-1.7C12.2 3 12.1 3 12 3c-0.1 0-0.2 0-0.3 0.1L10 4.8C9.8 5 9.8 5.3 10 5.5l0.9 0.9H9.3c-1.2 0-2.3 1-2.4 2.2l-0.5 6.2c-0.1 1.2 0.8 2.2 2.1 2.2H12h0 3.6C16.8 17.1 17.8 16 17.7 14.8"
-            />
+              d="M15.7 15.4c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C16.5 15 16.1 15.4 15.7 15.4M12 12.6H8.2c-0.3 0-0.5-0.3-0.5-0.6L8 8.6C8 8 8.6 7.5 9.2 7.5H12h0 0 2.8C15.4 7.5 16 8 16 8.6l0.3 3.4c0 0.3-0.2 0.6-0.5 0.6H12zM8.3 15.4c-0.5 0-0.8-0.4-0.8-0.8 0-0.5 0.4-0.8 0.8-0.8 0.5 0 0.8 0.4 0.8 0.8C9.2 15 8.8 15.4 8.3 15.4M10.9 5.1L12 4l1.1 1.1L12 6.3 10.9 5.1zM17.7 14.8l-0.5-6.2c-0.1-1.2-1.2-2.2-2.5-2.2h-1.5L14 5.5c0.2-0.2 0.2-0.5 0-0.7l-1.7-1.7C12.2 3 12.1 3 12 3c-0.1 0-0.2 0-0.3 0.1L10 4.8C9.8 5 9.8 5.3 10 5.5l0.9 0.9H9.3c-1.2 0-2.3 1-2.4 2.2l-0.5 6.2c-0.1 1.2 0.8 2.2 2.1 2.2H12h0 3.6C16.8 17.1 17.8 16 17.7 14.8" />
             <path
-              d="M8.1 18.7l-0.8 1.9c-0.1 0.2 0 0.3 0.2 0.3h0.7c0.2 0 0.4-0.1 0.4-0.3L9 18.7l0.2-1.1H8.6L8.1 18.7z"
-            />
+              d="M8.1 18.7l-0.8 1.9c-0.1 0.2 0 0.3 0.2 0.3h0.7c0.2 0 0.4-0.1 0.4-0.3L9 18.7l0.2-1.1H8.6L8.1 18.7z" />
             <path
-              d="M15.8 18.7l-0.5-1.1h-0.6l0.2 1.1 0.3 1.9c0 0.2 0.2 0.3 0.4 0.3h0.7c0.2 0 0.3-0.1 0.2-0.3L15.8 18.7z"
-            />
+              d="M15.8 18.7l-0.5-1.1h-0.6l0.2 1.1 0.3 1.9c0 0.2 0.2 0.3 0.4 0.3h0.7c0.2 0 0.3-0.1 0.2-0.3L15.8 18.7z" />
           </svg>
           <span>Tram</span>
         </label>
@@ -130,14 +79,9 @@
     <div class="fields nga-fast nga-fade">
       <label class="plain" for="SelectedBrand">Pass</label>
       <span class="stylized-select">
-        <select
-          id="SelectedBrand"
-          name="Brand"
-          aria-disabled="false"
-          data-ng-model="tickets.postJSON.brand"
+        <select id="SelectedBrand" name="Brand" aria-disabled="false" data-ng-model="tickets.postJSON.brand"
           data-ng-change="tickets.clearModes();tickets.swiftABT();tickets.swiftPAYG();tickets.getSwiftPAYG();tickets.ntrainOOC();tickets.selectPass();"
-          ng-disabled="tickets.postJSON.allowMetro || tickets.postJSON.allowBus || tickets.postJSON.allowTrain"
-        >
+          ng-disabled="tickets.postJSON.allowMetro || tickets.postJSON.allowBus || tickets.postJSON.allowTrain">
           <option value="">Select your pass</option>
           <option value="Diamond Bus">Diamond Bus</option>
           <!-- <option value="Johnsons">Johnsons</option> -->
@@ -156,30 +100,73 @@
   </div>
   <!-- /Mode & Pass -->
 
-  <div
-  data-ng-if="tickets.postJSON.allowTrain"
-  class="grid-12 errors"
->
-  <div class="boxin -messages">
-    <p><strong>Ticket advice</strong></p>
-    <p>
-      Our finder can tell you about tickets covering rail zones but it may be cheaper to buy a station to station ticket. You can check this at
-      <a
-      href="http://www.nationalrail.co.uk/"
-      target="_blank"
-      >National Rail</a>  
-    </p>
+  <div data-ng-if="tickets.postJSON.allowTrain" class="grid-12 errors">
+    <div class="boxin -messages">
+      <p><strong>Ticket advice</strong></p>
+      <p>
+        Our finder can tell you about tickets covering rail zones but it may be cheaper to buy a station to station
+        ticket. You can check this at
+        <a href="http://www.nationalrail.co.uk/" target="_blank">National Rail</a>
+      </p>
+    </div>
   </div>
-</div>
 
   <!-- Traveller -->
   <div class="rowcontainer traveller">
-    <div
-      class="grid-5"
-      ng-hide="tickets.passValue == 'Swift PAYG' || tickets.passValue == 'Swift Go'"
-      data-ng-if="tickets.postJSON.allowBus || tickets.postJSON.allowTrain || tickets.postJSON.allowMetro || tickets.postJSON.brand"
-    >
-      <span
+    <div class="grid-5" ng-hide="tickets.passValue == 'Swift PAYG' || tickets.passValue == 'Swift Go'"
+      data-ng-if="tickets.postJSON.allowBus || tickets.postJSON.allowTrain || tickets.postJSON.allowMetro || tickets.postJSON.brand">
+      <label class="plain" for="SelectedPassengerType">Traveller</label>
+      <!-- accordion Help with Traveller selection -->
+      <div class="wmnds-accordion">
+        <button type="button" aria-controls="accordion-01" id="accordion-01-button"
+          class="wmnds-accordion__summary-wrapper sm__ticket_finder_accordion_button" aria-expanded="false"
+          data-ng-click="tickets.openAccordion($event)">
+          <!-- accordion summary -->
+          <span class="wmnds-accordion__summary">
+            <span class="wmnds-accordion__heading-text">Help with Traveller selection</span>
+          </span>
+          <!-- plus icon -->
+          <svg class="wmnds-accordion__icon" aria-hidden="true" focusable="false">
+            <use xlink:href="#wmnds-general-expand" href="#wmnds-general-expand"></use>
+          </svg>
+          <!-- minus icon -->
+          <svg class="wmnds-accordion__icon wmnds-accordion__icon--minimise" aria-hidden="true" focusable="false">
+            <use xlink:href="#wmnds-general-minimise" href="#wmnds-general-minimise"></use>
+          </svg>
+        </button>
+
+        <!-- accordion content -->
+        <div class="wmnds-accordion__content" id="accordion-01" role="region" aria-labelledby="accordion-01-button"
+          hidden>
+          Young Person up to 18: - For children aged 5-15 inclusive and holders of the Network West Midlands
+          <a href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/'
+            target='_blank'>16-18 photocard</a>. <br><br>
+
+          Student 18+: - For students who are in full time education aged 18+ or those aged 16-18 who are NOT entitled
+          to the
+          Network West Midlands <a
+            href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/'
+            target='_blank'>16-18 photocard</a>.
+          Proof of full-time education and two passport sized photographs will be required to buy this ticket (if
+          purchasing from rail station).
+          Or, it may be loaded to a Swift photocard.<br><br>
+
+          Group/Family: these
+          vary; check full
+          ticket descriptions.<br><br>
+
+          Older Persons Passholder: - holder of an English National Concessionary Travel Pass <br><br>
+
+          Disabled Passholder - holder of an English National Concessionary Travel Pass<br><br>
+
+          If you don't match any criteria -
+          search for adult tickets.
+        </div>
+      </div>
+
+
+
+      <!-- <span
         tooltip
         tooltipc="
             Young Person up to 18: - For children aged 5-15 inclusive and holders of the Network West Midlands 
@@ -202,16 +189,12 @@
             search for adult tickets.
             "
         class="help-link float--right"
-      ></span>
+      ></span> -->
 
-      <label class="plain" for="SelectedPassengerType">Traveller</label>
+
       <span class="stylized-select">
-        <select
-          id="SelectedPassengerType"
-          name="PassengerType"
-          aria-disabled="false"
-          data-ng-model="tickets.postJSON.passengerType"
-        >
+        <select id="SelectedPassengerType" name="PassengerType" aria-disabled="false"
+          data-ng-model="tickets.postJSON.passengerType">
           <option value="">Select Traveller</option>
           <option value="Adult">Adult</option>
           <option value="Child">Young Person up to 18</option>
@@ -225,10 +208,7 @@
       </span>
     </div>
     <div class="grid-7"></div>
-    <div
-      data-ng-if="tickets.postJSON.passengerType == 'Concessionary'"
-      class="grid-12 errors"
-    >
+    <div data-ng-if="tickets.postJSON.passengerType == 'Concessionary'" class="grid-12 errors">
       <div class="boxin -messages">
         <p><strong>Free Travel in the West Midlands</strong></p>
         <p>
@@ -236,17 +216,11 @@
           <strong>Disabled Concessionary Travel Passes</strong> you can travel
           off-peak on the bus across the UK as well as on the train and tram
           within Network West Midlands area. Please visit either the
-          <a
-            href="https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/get-an-older-person-s-travel-pass/"
-            target="_blank"
-            >Older Person’s</a
-          >
+          <a href="https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/get-an-older-person-s-travel-pass/"
+            target="_blank">Older Person’s</a>
           or
-          <a
-            href="https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/get-a-disabled-person-s-pass/"
-            target="_blank"
-            >Disabled Person’s</a
-          >
+          <a href="https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/get-a-disabled-person-s-pass/"
+            target="_blank">Disabled Person’s</a>
           pages for more information on when and how you can apply or renew,
           eligibility and where and when you can travel.
         </p>
@@ -260,191 +234,80 @@
   <!-- /Traveller -->
 
   <!-- Rail Stations -->
-  <div
-    class="grid-12"
-    data-ng-if="tickets.postJSON.allowTrain && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'nnetwork' && tickets.postJSON.passengerType"
-  >
+  <div class="grid-12"
+    data-ng-if="tickets.postJSON.allowTrain && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'nnetwork' && tickets.postJSON.passengerType">
     <div class="grid-12">
-      <label for="stationFrom_value" class="plain title"
-        >Which rail stations will you use?
-        <strong
-          class="blue"
-          data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County'"
-          >(Optional)</strong
-        ><strong
-          class="type--red"
-          data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County'"
-          >(Required)</strong
-        ></label
-      >
+      <label for="stationFrom_value" class="plain title">Which rail stations will you use?
+        <strong class="blue"
+          data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County'">(Optional)</strong><strong class="type--red"
+          data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County'">(Required)</strong></label>
     </div>
 
     <div class="grid-6 padding-right">
       <div data-ng-init="tickets.getStations();tickets.setStations();">
-        <label class="plain-small visuallyhidden" for="stationFrom_value"
-          >From</label
-        >
+        <label class="plain-small visuallyhidden" for="stationFrom_value">From</label>
         <div data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County'">
-          <div
-            angucomplete-alt
-            id="stationFrom"
-            placeholder="From"
-            pause="100"
-            selected-object="tickets.stationFrom"
-            local-data="tickets.stationList"
-            search-fields="name"
-            title-field="name"
-            minlength="1"
-            input-class="form-control padding-right"
-            match-class="highlight"
-            initial-value="tickets.stationFromName"
-            field-required-class="field-required"
-            field-required="stationFromReq"
-            input-name="fromStation"
-            input-changed="fromStationInputChanged"
-            focus-in="tickets.fromFocusIn()"
-            focus-out="fromFocusOut()"
-          ></div>
+          <div angucomplete-alt id="stationFrom" placeholder="From" pause="100" selected-object="tickets.stationFrom"
+            local-data="tickets.stationList" search-fields="name" title-field="name" minlength="1"
+            input-class="form-control padding-right" match-class="highlight" initial-value="tickets.stationFromName"
+            field-required-class="field-required" field-required="stationFromReq" input-name="fromStation"
+            input-changed="fromStationInputChanged" focus-in="tickets.fromFocusIn()" focus-out="fromFocusOut()"></div>
         </div>
-        <div
-          data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType"
-        >
-          <div
-            angucomplete-alt
-            id="stationFromOOC"
-            placeholder="To / From"
-            pause="100"
-            selected-object="tickets.stationFrom"
-            local-data="tickets.stationList"
-            search-fields="name"
-            title-field="name"
-            minlength="1"
-            input-class="form-control padding-right"
-            match-class="highlight"
-            initial-value="tickets.stationFromName"
-            field-required-class="field-required"
-            field-required="stationFromReqOOC"
-            input-name="fromStation"
-            input-changed="fromStationInputChanged"
-            focus-in="fromFocusIn()"
-            focus-out="fromFocusOut()"
-          ></div>
+        <div data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType">
+          <div angucomplete-alt id="stationFromOOC" placeholder="To / From" pause="100"
+            selected-object="tickets.stationFrom" local-data="tickets.stationList" search-fields="name"
+            title-field="name" minlength="1" input-class="form-control padding-right" match-class="highlight"
+            initial-value="tickets.stationFromName" field-required-class="field-required"
+            field-required="stationFromReqOOC" input-name="fromStation" input-changed="fromStationInputChanged"
+            focus-in="fromFocusIn()" focus-out="fromFocusOut()"></div>
         </div>
 
-        <a
-          data-ng-if="tickets.stationFromName || fromStationText != null && tickets.stationFromName == null && stationFromReq == true"
-          class="btn-link float--right"
-          href=""
-          data-ng-click="tickets.clearFromStation();"
-          >Clear</a
-        >
-        <div
-          class="result boxin bg--grey bg--tint bdr-bottom--blue"
-          data-ng-show="tickets.stationFromName"
-        >
+        <a data-ng-if="tickets.stationFromName || fromStationText != null && tickets.stationFromName == null && stationFromReq == true"
+          class="btn-link float--right" href="" data-ng-click="tickets.clearFromStation();">Clear</a>
+        <div class="result boxin bg--grey bg--tint bdr-bottom--blue" data-ng-show="tickets.stationFromName">
           <div>
             You selected <strong>{{tickets.stationFromName}}</strong> station
             which is
-            <strong
-              >{{ tickets.stationFromNameOoc ? station.Name + ' Out of County':
-              station.name + ' Zone ' + tickets.fromZoneNumber }}</strong
-            >.
+            <strong>{{ tickets.stationFromNameOoc ? station.Name + ' Out of County':
+              station.name + ' Zone ' + tickets.fromZoneNumber }}</strong>.
           </div>
         </div>
       </div>
     </div>
 
     <div class="grid-6 padding-left">
-      <div
-        class="fields passselect nga-fast nga-fade"
-        style="margin:0px"
-        data-ng-hide="!tickets.stationFromName"
-      >
-        <label class="plain-small visuallyhidden" for="stationTo_value"
-          >To
-          <span
-            data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType"
-            >Out of County Station</span
-          ></label
-        >
-        <div
-          data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County' || tickets.postJSON.brand == 'ntrain'"
-        >
-          <div
-            angucomplete-alt
-            id="stationTo"
-            placeholder="To"
-            pause="100"
-            selected-object="tickets.stationTo"
-            local-data="tickets.stationList"
-            search-fields="name"
-            title-field="name"
-            minlength="1"
-            input-class="form-control form-control-small"
-            match-class="highlight"
-            initial-value="tickets.stationToName"
-            field-required-class="field-required"
-            field-required="stationToReq"
-            input-name="toStation"
-            input-changed="toStationInputChanged"
-            focus-in="toFocusIn()"
-            focus-out="toFocusOut()"
-          ></div>
+      <div class="fields passselect nga-fast nga-fade" style="margin:0px" data-ng-hide="!tickets.stationFromName">
+        <label class="plain-small visuallyhidden" for="stationTo_value">To
+          <span data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType">Out of
+            County Station</span></label>
+        <div data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County' || tickets.postJSON.brand == 'ntrain'">
+          <div angucomplete-alt id="stationTo" placeholder="To" pause="100" selected-object="tickets.stationTo"
+            local-data="tickets.stationList" search-fields="name" title-field="name" minlength="1"
+            input-class="form-control form-control-small" match-class="highlight" initial-value="tickets.stationToName"
+            field-required-class="field-required" field-required="stationToReq" input-name="toStation"
+            input-changed="toStationInputChanged" focus-in="toFocusIn()" focus-out="toFocusOut()"></div>
         </div>
       </div>
       <!-- If pass is ntrain-->
-      <div
-        data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County'"
+      <div data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County'"
         data-ng-if="tickets.postJSON.brand == 'ntrain' && tickets.postJSON.passengerType"
-        data-ng-init="tickets.geticStations();"
-      >
-        <div
-          angucomplete-alt
-          id="stationTo2"
-          placeholder="To"
-          pause="100"
-          selected-object="tickets.stationTo"
-          local-data="tickets.stationicList"
-          search-fields="name"
-          title-field="name"
-          minlength="1"
-          input-class="form-control form-control-small"
-          match-class="highlight"
-          initial-value="tickets.stationToName"
-          field-required-class="field-required"
-          field-required="stationToReq"
-          input-name="toStation"
-          input-changed="toStationInputChanged"
-          focus-in="toFocusIn()"
-          focus-out="toFocusOut()"
-        ></div>
+        data-ng-init="tickets.geticStations();">
+        <div angucomplete-alt id="stationTo2" placeholder="To" pause="100" selected-object="tickets.stationTo"
+          local-data="tickets.stationicList" search-fields="name" title-field="name" minlength="1"
+          input-class="form-control form-control-small" match-class="highlight" initial-value="tickets.stationToName"
+          field-required-class="field-required" field-required="stationToReq" input-name="toStation"
+          input-changed="toStationInputChanged" focus-in="toFocusIn()" focus-out="toFocusOut()"></div>
       </div>
       <!-- If pass is ntrain - Out of County-->
-      <div
-        data-ng-hide="!tickets.stationFromName"
+      <div data-ng-hide="!tickets.stationFromName"
         data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType"
-        data-ng-init="tickets.getoocStations();"
-      >
-        <div
-          angucomplete-alt
-          id="stationTo3"
-          placeholder="To / From out of county station"
-          pause="100"
-          selected-object="tickets.stationTo"
-          local-data="tickets.stationoocList"
-          search-fields="name"
-          title-field="name"
-          minlength="1"
-          input-class="form-control form-control-small"
-          match-class="highlight"
-          initial-value="tickets.stationToName"
-          field-required-class="field-required"
-          field-required="stationToReqOOC"
-          input-name="toStation"
-          input-changed="toStationInputChanged"
-          focus-in="toFocusIn()"
-          focus-out="toFocusOut()"
-        ></div>
+        data-ng-init="tickets.getoocStations();">
+        <div angucomplete-alt id="stationTo3" placeholder="To / From out of county station" pause="100"
+          selected-object="tickets.stationTo" local-data="tickets.stationoocList" search-fields="name"
+          title-field="name" minlength="1" input-class="form-control form-control-small" match-class="highlight"
+          initial-value="tickets.stationToName" field-required-class="field-required" field-required="stationToReqOOC"
+          input-name="toStation" input-changed="toStationInputChanged" focus-in="toFocusIn()" focus-out="toFocusOut()">
+        </div>
       </div>
       <!-- If pass is In County-->
       <!--<div data-ng-if="tickets.postJSON.brand == 'ntrain' && tickets.postJSON.passengerType" data-ng-init="tickets.geticStations();">
@@ -455,25 +318,16 @@
                 </div>
             </div>-->
       <div data-ng-hide="!tickets.stationFromName">
-        <a
-          data-ng-if="tickets.stationToName || stationToName || toStationText != null && tickets.stationToName == null && stationToReq == true"
-          class="btn-link float--right"
-          href=""
-          data-ng-click="tickets.clearToStation();"
-          >Clear</a
-        >
+        <a data-ng-if="tickets.stationToName || stationToName || toStationText != null && tickets.stationToName == null && stationToReq == true"
+          class="btn-link float--right" href="" data-ng-click="tickets.clearToStation();">Clear</a>
 
-        <div
-          class="result boxin bg--grey bg--tint bdr-bottom--blue"
-          data-ng-show="tickets.stationToName || stationToName"
-        >
+        <div class="result boxin bg--grey bg--tint bdr-bottom--blue"
+          data-ng-show="tickets.stationToName || stationToName">
           <div>
             You selected <strong>{{tickets.stationToName}}</strong> station
             which is
-            <strong
-              >{{ tickets.stationToNameOoc ? station.Name + ' Out of County':
-              station.name + ' Zone ' + tickets.toZoneNumber }}</strong
-            >.
+            <strong>{{ tickets.stationToNameOoc ? station.Name + ' Out of County':
+              station.name + ' Zone ' + tickets.toZoneNumber }}</strong>.
           </div>
         </div>
       </div>
@@ -482,72 +336,33 @@
 
   <!-- Via station -->
   <div class="rowcontainer">
-    <div
-      class="grid-6 padding-right"
-      ng-hide="tickets.passValue == 'Swift PAYG' || !tickets.stationFromName"
-      data-ng-if="tickets.postJSON.allowBus || tickets.postJSON.allowTrain || tickets.postJSON.allowMetro || tickets.postJSON.brand"
-    >
+    <div class="grid-6 padding-right" ng-hide="tickets.passValue == 'Swift PAYG' || !tickets.stationFromName"
+      data-ng-if="tickets.postJSON.allowBus || tickets.postJSON.allowTrain || tickets.postJSON.allowMetro || tickets.postJSON.brand">
       <div
         data-ng-if="tickets.postJSON.allowTrain && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'nnetwork' && tickets.postJSON.passengerType"
-        class="help-section grid-12"
-      >
-        <div
-          class="acc accordion-vertical js-accordion"
-          data-module="accordion"
-        ></div>
-        <div
-          class="acc__item"
-          ng-class="{true: 'acc--active', false: 'acc--active2'}[tickets.stationVia == true]"
-        >
-          <label class="btn--navy acc__trigger"
-            >Add via station<input
-              class="hidden"
-              type="checkbox"
-              ng-model="tickets.stationVia"/></label
-          ><br />
+        class="help-section grid-12">
+        <div class="acc accordion-vertical js-accordion" data-module="accordion"></div>
+        <div class="acc__item" ng-class="{true: 'acc--active', false: 'acc--active2'}[tickets.stationVia == true]">
+          <label class="btn--navy acc__trigger">Add via station<input class="hidden" type="checkbox"
+              ng-model="tickets.stationVia" /></label><br />
           <div ng-show="tickets.stationVia" class="railhelp">
-            <label class="plain-small visuallyhidden" for="stationViaOne_value"
-              >Via</label
-            >
-            <div
-              angucomplete-alt
-              id="stationViaOne"
-              placeholder="Via"
-              pause="100"
-              selected-object="tickets.stationViaOne"
-              local-data="tickets.stationList"
-              search-fields="name"
-              title-field="name"
-              minlength="1"
-              input-class="form-control padding-right"
-              match-class="highlight"
-              initial-value="tickets.stationViaOneName"
-              input-name="stationViaOne"
-              input-changed="viaOneStationInputChanged"
-              field-required-class="field-required"
-              field-required="stationViaOneReq"
-              focus-in="stationViaOneFocusIn()"
-              focus-out="stationViaOneFocusOut()"
-            ></div>
-            <a
-              data-ng-if="tickets.stationViaOneName != null || viaOneStationText != null"
-              class="btn-link float--right"
-              href=""
-              data-ng-click="tickets.clearViaOneStation();"
-              >Clear</a
-            >
+            <label class="plain-small visuallyhidden" for="stationViaOne_value">Via</label>
+            <div angucomplete-alt id="stationViaOne" placeholder="Via" pause="100"
+              selected-object="tickets.stationViaOne" local-data="tickets.stationList" search-fields="name"
+              title-field="name" minlength="1" input-class="form-control padding-right" match-class="highlight"
+              initial-value="tickets.stationViaOneName" input-name="stationViaOne"
+              input-changed="viaOneStationInputChanged" field-required-class="field-required"
+              field-required="stationViaOneReq" focus-in="stationViaOneFocusIn()" focus-out="stationViaOneFocusOut()">
+            </div>
+            <a data-ng-if="tickets.stationViaOneName != null || viaOneStationText != null" class="btn-link float--right"
+              href="" data-ng-click="tickets.clearViaOneStation();">Clear</a>
 
-            <div
-              class="result boxin bg--grey bg--tint"
-              data-ng-show="tickets.stationViaOneName || stationViaOneName"
-            >
+            <div class="result boxin bg--grey bg--tint" data-ng-show="tickets.stationViaOneName || stationViaOneName">
               <div>
                 You selected
                 <strong>{{tickets.stationViaOneName}}</strong> station which is
-                <strong
-                  >{{ stationViaOneNameOoc ? station.Name + ' Out of County':
-                  station.name + ' Zone ' + tickets.ViaOneZoneNumber }}</strong
-                >.
+                <strong>{{ stationViaOneNameOoc ? station.Name + ' Out of County':
+                  station.name + ' Zone ' + tickets.ViaOneZoneNumber }}</strong>.
               </div>
             </div>
           </div>
@@ -561,32 +376,20 @@
   <!-- Help section if station is not listed in auto complete -->
   <div
     data-ng-if="tickets.postJSON.allowTrain && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'ntrain' && tickets.postJSON.passengerType || tickets.postJSON.brand == 'nnetwork' && tickets.postJSON.passengerType"
-    class="help-section grid-12"
-  >
-    <label class="blue btn-link"
-      >Station not listed?
-      <input class="hidden" type="checkbox" ng-model="stationNotListed"/></label
-    ><br />
-    <div
-      ng-show="stationNotListed"
-      class="railhelp boxin bg--grey bg--tint bdr-bottom--blue"
-    >
-      <p
-        data-ng-hide="tickets.postJSON.brand == 'ntrain' || tickets.postJSON.brand == null"
-      >
+    class="help-section grid-12">
+    <label class="blue btn-link">Station not listed?
+      <input class="hidden" type="checkbox" ng-model="stationNotListed" /></label><br />
+    <div ng-show="stationNotListed" class="railhelp boxin bg--grey bg--tint bdr-bottom--blue">
+      <p data-ng-hide="tickets.postJSON.brand == 'ntrain' || tickets.postJSON.brand == null">
         Is your station in county? Try changing the pass to ntrain
       </p>
-      <p
-        data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County' || tickets.postJSON.brand == null"
-      >
+      <p data-ng-hide="tickets.postJSON.brand == 'ntrain - Out of County' || tickets.postJSON.brand == null">
         Is your station out of county? Try changing the pass to ntrain - Out of
         County
       </p>
       <p>
         Please refer to
-        <a href="http://www.nationalrail.co.uk/" target="_blank" rel="noopener"
-          >National Rail</a
-        >
+        <a href="http://www.nationalrail.co.uk/" target="_blank" rel="noopener">National Rail</a>
         for journeys from or to a station not listed
       </p>
     </div>
@@ -596,19 +399,14 @@
   <!-- error messages -->
   <div
     data-ng-if="tickets.stationFromName && !tickets.stationToName || !tickets.stationFromName && tickets.stationToName || viaOneStationText != null && !tickets.stationFromName && !tickets.stationToName"
-    data-ng-hide="stationFromName == '[]' || tickets.postJSON.brand == 'ntrain - Out of County'"
-    class="grid-12 errors"
-  >
+    data-ng-hide="stationFromName == '[]' || tickets.postJSON.brand == 'ntrain - Out of County'" class="grid-12 errors">
     <div class="boxin -messages">
       In order to carry out a rail station search you need to add the To & From
       stations.
     </div>
   </div>
-  <div
-    data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType"
-    data-ng-hide="tickets.stationFromName && tickets.stationToName"
-    class="grid-12 errors"
-  >
+  <div data-ng-if="tickets.postJSON.brand == 'ntrain - Out of County' && tickets.postJSON.passengerType"
+    data-ng-hide="tickets.stationFromName && tickets.stationToName" class="grid-12 errors">
     <div class="boxin -messages">
       In order to carry out an out of county rail station search you need to add
       the To & From stations.
@@ -616,24 +414,20 @@
   </div>
   <div
     data-ng-if="fromStationText != null && tickets.stationFromName == null && stationFromReq == true && tickets.stationToName != null"
-    class="grid-12 errors"
-  >
+    class="grid-12 errors">
     <div class="boxin -messages">
       We do not provide tickets from {{fromStationText}}. Please choose another.
     </div>
   </div>
   <div
     data-ng-if="toStationText != null && tickets.stationToName == null && stationToReq == true && tickets.stationFromName != null"
-    class="grid-12 errors"
-  >
+    class="grid-12 errors">
     <div class="boxin -messages">
       We do not provide tickets to {{toStationText}}. Please choose another.
     </div>
   </div>
-  <div
-    data-ng-if="viaOneStationText != null && tickets.stationViaOneName == null && stationViaOneReq == true"
-    class="grid-12 errors"
-  >
+  <div data-ng-if="viaOneStationText != null && tickets.stationViaOneName == null && stationViaOneReq == true"
+    class="grid-12 errors">
     <div class="boxin -messages">
       We do not provide tickets via {{viaOneStationText}}. Please choose
       another.
@@ -641,8 +435,7 @@
   </div>
   <div
     data-ng-if="fromfocusState == 'Out' && tickets.stationFromName == null && stationFromReq == true && tofocusState == 'Out' && tickets.stationToName == null && stationToReq == true"
-    class="grid-12 errors"
-  >
+    class="grid-12 errors">
     <div class="boxin -messages">
       We do not provide tickets from {{fromStationText}} to {{toStationText}}.
       Please choose another.
@@ -653,54 +446,30 @@
   <!-- /Rail Stations -->
 
   <!-- Duration -->
-  <div
-    class="fields how-long grid-12"
+  <div class="fields how-long grid-12"
     ng-hide="tickets.passValue == 'Swift PAYG' || tickets.passValue == 'Swift Go' || !tickets.postJSON.passengerType"
-    data-ng-if="tickets.postJSON.passengerType != '' && (tickets.postJSON.allowBus || tickets.postJSON.allowTrain || tickets.postJSON.allowMetro || tickets.postJSON.brand)"
-  >
+    data-ng-if="tickets.postJSON.passengerType != '' && (tickets.postJSON.allowBus || tickets.postJSON.allowTrain || tickets.postJSON.allowMetro || tickets.postJSON.brand)">
     <label class="plain duration">Duration</label>
     <div class="labels-new">
-      <span
-        class="icon-stylized-new"
-        ng-hide="tickets.postJSON.brand == 'ntrain - Out of County' || tickets.postJSON.brand == 'ntrain'"
-      >
-        <input
-          type="radio"
-          id="DurationDay"
-          name="TimeBand"
-          value="Pay on day / 1 day"
-          data-ng-model="tickets.postJSON.timeBand"
-        />
+      <span class="icon-stylized-new"
+        ng-hide="tickets.postJSON.brand == 'ntrain - Out of County' || tickets.postJSON.brand == 'ntrain'">
+        <input type="radio" id="DurationDay" name="TimeBand" value="Pay on day / 1 day"
+          data-ng-model="tickets.postJSON.timeBand" />
         <label for="DurationDay"> <span></span>a day</label>
       </span>
       <span class="icon-stylized-new">
-        <input
-          type="radio"
-          id="DurationWeek"
-          name="TimeBand"
-          value="Less than a month"
-          data-ng-model="tickets.postJSON.timeBand"
-        />
+        <input type="radio" id="DurationWeek" name="TimeBand" value="Less than a month"
+          data-ng-model="tickets.postJSON.timeBand" />
         <label for="DurationWeek"> <span></span>Less than a month</label>
       </span>
       <span class="icon-stylized-new">
-        <input
-          type="radio"
-          id="DurationMonth"
-          name="TimeBand"
-          value="About a month"
-          data-ng-model="tickets.postJSON.timeBand"
-        />
+        <input type="radio" id="DurationMonth" name="TimeBand" value="About a month"
+          data-ng-model="tickets.postJSON.timeBand" />
         <label for="DurationMonth"> <span></span>About a month</label>
       </span>
       <span class="icon-stylized-new">
-        <input
-          type="radio"
-          id="DurationTerm"
-          name="TimeBand"
-          value="Longer than a month"
-          data-ng-model="tickets.postJSON.timeBand"
-        />
+        <input type="radio" id="DurationTerm" name="TimeBand" value="Longer than a month"
+          data-ng-model="tickets.postJSON.timeBand" />
         <label for="DurationTerm"> <span></span>Longer than a month</label>
       </span>
       <!-- <span class="icon-stylized-new">
@@ -711,14 +480,10 @@
   </div>
   <!-- /Duration -->
 
-  <button
-    id="sbmBtn"
+  <button id="sbmBtn"
     data-ng-if="tickets.postJSON.passengerType && tickets.postJSON.timeBand || tickets.postJSON.brand == 'Swift PAYG' || tickets.passValue == 'Swift Go'"
     data-ng-hide="tickets.stationFromName && !tickets.stationToName || !tickets.stationFromName && tickets.stationToName || viaOneStationText != null && !tickets.stationFromName && !tickets.stationToName"
-    type="submit"
-    class="btn btn--arrow submitSpinner nga-fast nga-fade btn--navy"
-    ng-disabled="tsearch.$invalid"
-  >
+    type="submit" class="btn btn--arrow submitSpinner nga-fast nga-fade btn--navy" ng-disabled="tsearch.$invalid">
     Find tickets
   </button>
 </form>


### PR DESCRIPTION
This PR fixes an accessibility issue with modal focus order, where the modal content was discovered before the associated question mark trigger, confusing screen readers and keyboard users.

Issue URL: https://github.com/west-midlands-ca/ticket-finder/issues/7

🐞 Issue identified

The modal appears before the question mark icon in the DOM order

When backwards tabbing, the screen reader discovers the modal from bottom to top

This results in the modal being announced out of context, before the user reaches the trigger

Behaviour is confusing and inconsistent for assistive technology users

✅ Fixes applied

✔ Corrected focus and reading order so the question mark trigger is encountered first
✔ Ensured the modal is announced only after activation
✔ Prevented premature discovery of modal content during backward tabbing
✔ Improved overall screen reader and keyboard navigation flow

Popup replaced by https://designsystem.tfwm.org.uk/components/accordion/

🧪 Accessibility Testing

✔ Tested using Windows Narrator
✔ Tested using NVDA screen reader