### PR TITLE
Blank / Empty Lines Within Text – Accessibility Fix applied

### DIFF
--- a/src/app/tickets/views/shared/initial-search.html
+++ b/src/app/tickets/views/shared/initial-search.html
@@ -138,59 +138,28 @@
         <!-- accordion content -->
         <div class="wmnds-accordion__content" id="accordion-01" role="region" aria-labelledby="accordion-01-button"
           hidden>
-          Young Person up to 18: - For children aged 5-15 inclusive and holders of the Network West Midlands
-          <a href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/'
-            target='_blank'>16-18 photocard</a>. <br><br>
+            <p>Young Person up to 18: For children aged 5-15 inclusive and holders of the Network West Midlands.
+            <a href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/'
+            target='_blank'>16-18 photocard</a></p>
 
-          Student 18+: - For students who are in full time education aged 18+ or those aged 16-18 who are NOT entitled
-          to the
-          Network West Midlands <a
+            <p>Student 18+: For students who are in full time education aged 18+ or those aged 16-18 who are NOT entitled
+            to the
+            Network West Midlands. <a
             href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/'
             target='_blank'>16-18 photocard</a>.
-          Proof of full-time education and two passport sized photographs will be required to buy this ticket (if
-          purchasing from rail station).
-          Or, it may be loaded to a Swift photocard.<br><br>
+            Proof of full-time education and two passport sized photographs will be required to buy this ticket (if
+            purchasing from rail station).
+            Or, it may be loaded to a Swift photocard.</p>
 
-          Group/Family: these
-          vary; check full
-          ticket descriptions.<br><br>
+            <p>Group/Family: These vary; check full ticket descriptions.</p>
 
-          Older Persons Passholder: - holder of an English National Concessionary Travel Pass <br><br>
+            <p>Older Persons Passholder: Holder of an English National Concessionary Travel Pass</p>
 
-          Disabled Passholder - holder of an English National Concessionary Travel Pass<br><br>
+          <p>Disabled Passholder: Holder of an English National Concessionary Travel Pass</p>
 
-          If you don't match any criteria -
-          search for adult tickets.
+          <p>If you don't match any criteria, search for adult tickets.</p>
         </div>
       </div>
-
-
-
-      <!-- <span
-        tooltip
-        tooltipc="
-            Young Person up to 18: - For children aged 5-15 inclusive and holders of the Network West Midlands 
-            <a href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/' target='_blank'>16-18 photocard</a>. <br><br>
-
-            Student 18+: - For students who are in full time education aged 18+ or those aged 16-18 who are NOT entitled to the 
-            Network West Midlands <a href='https://www.tfwm.org.uk/swift-and-tickets/discounts-and-free-travel-passes/swift-16-18-photocard/' target='_blank'>16-18 photocard</a>. 
-            Proof of full-time education and two passport sized photographs will be required to buy this ticket (if purchasing from rail station). 
-            Or, it may be loaded to a Swift photocard.<br><br>
-
-            Group/Family: these
-            vary; check full
-            ticket descriptions.<br><br>
-
-            Older Persons Passholder: - holder of an English National Concessionary Travel Pass <br><br>
-
-            Disabled Passholder  - holder of an English National Concessionary Travel Pass<br><br>
-
-            If you don't match any criteria -
-            search for adult tickets.
-            "
-        class="help-link float--right"
-      ></span> -->
-
 
       <span class="stylized-select">
         <select id="SelectedPassengerType" name="PassengerType" aria-disabled="false"


### PR DESCRIPTION
**Issue:**
Empty paragraphs and multiple <br> tags were being used to create visual spacing within descriptive text. Screen readers announce these as “blank”, which interrupts reading flow and impacts understanding for assistive technology users.
(WCAG 2.1: 1.3.1, 2.4.3, Level A – Medium)

Issue Url: https://github.com/west-midlands-ca/ticket-finder/issues/4

**Fixes applied:**
✅ Removed unnecessary <br> tags that were creating empty lines for screen readers
✅ Ensured content is structured using proper semantic <p> elements only
✅ Preserved existing visual layout while handling spacing via CSS where required
✅ Eliminated “blank” announcements caused by non-semantic spacing
✅ Verified improved reading flow using NVDA and Windows Narrator

**Before Fix:** 
<img width="228" height="421" alt="image" src="https://github.com/user-attachments/assets/92a067a1-1e11-41cd-880d-a43d79786dde" />
 
**After fix:**
<img width="245" height="628" alt="image" src="https://github.com/user-attachments/assets/5f3fb88e-049e-4124-891f-8ab2682e13e2" />

**Testing:**

Tested with Windows Narrator

Tested with NVDA

Verified no “blank” announcements during content reading