### PR TITLE
Add visible focus indicator to Mode selection buttons (Bus / Train / Tram) #3

### DIFF
--- a/src/app/sass/assets/nwm-custom.scss
+++ b/src/app/sass/assets/nwm-custom.scss
@@ -3089,6 +3089,23 @@ a.icon-stylized-new {
     padding: 15px 40px;
 }
 
+/* Visually hide the checkbox while keeping it keyboard and screen-reader accessible, preventing the native focus indicator. */
+.icon-stylized-new input[type="checkbox"] {
+  position: absolute;
+  left: -9999px;   // move focus ring off-screen
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+/* Show a strong focus indicator on the visible control (label) */
+.icon-stylized-new > input[type="checkbox"]:focus-visible + label {
+  outline: 4px solid #008dc9;     /* replace with your focus token/colour */
+}
+
 .labels-new {
     overflow: hidden;
     width: 100%;


### PR DESCRIPTION
PR: https://github.com/west-midlands-ca/ticket-finder/issues/3

**Issue identified**
- Mode selection buttons (Bus, Train, Tram) did not show a visible focus indicator
- Keyboard users could not visually identify which option had focus
- A small native browser focus artefact (tiny square) appeared instead
- Focus visibility did not meet WCAG 2.2 AA expectations

**Fixes applied**
✔ Visually hid the native checkbox while keeping it keyboard and screen-reader accessible
✔ Removed the default browser focus artefact on the checkbox
✔ Applied a clear, high-contrast focus indicator to the visible label
✔ Ensured consistent focus behaviour across Bus, Train and Tram options
✔ Improved overall keyboard and screen reader usability

**Accessibility Testing**
✔ Tested using keyboard navigation (Tab / Shift+Tab)
✔ Tested using Windows Narrator
✔ Tested using NVDA screen reader
✔ Verified in Chrome and Edge
