### PR TITLE
Accessibility: Improve price suffix handling and screen reader output #2

### DIFF
--- a/src/app/controller/tickets.controller.js
+++ b/src/app/controller/tickets.controller.js
@@ -90,6 +90,8 @@
     vm.deviceDetect = deviceDetect; // Function to detect device
     vm.selectPass = selectPass; // Function to reset filters if select your pass is selected
     vm.openAccordion = openAccordion; // Function to open accordion 
+    vm.getValiditySuffix = getValiditySuffix; // Function to get the suffix for the price based on the ticket validity
+    vm.srPronunciation = srPronunciation; // Function to get the pronunciation for screen readers
     // Set up the default Vars on page load, and so that they can be reset with 'reset filters' button
     function defaultVars() {
       vm.all = []; // Set results to blank array
@@ -1727,6 +1729,45 @@
         accordion.classList.add('wmnds-is--open');
         accordionBtn.setAttribute('aria-expanded', 'true');
       }
+    }
+
+    // Returns the appropriate validity suffix (day, week, month, year) based on ticket rules
+    function getValiditySuffix(ticket) {
+      // If ticketCurrentAmount AND onlineCurrentAmount, show no suffix (matches your hide condition)
+      if (ticket.ticketCurrentAmount && ticket.onlineCurrentAmount) return '';
+
+      // Map validityId to suffix
+      switch (ticket.validityId) {
+        case 450930002:
+        case 450930006:
+        case 450930010:
+          return ' per month';
+
+        case 450930000:
+          // your existing exception rules
+          if (ticket.type === 'Carnet' || ticket.id === '811') return '';
+          return ' a day';
+
+        case 450930001:
+          return ' a week';
+
+        case 450930003:
+          return ' for 1 year';
+
+        default:
+          return '';
+      }
+    }
+
+    // Ensures screen readers pronounce nbus, ntrain, and nnetwork correctly
+    function srPronunciation(text) {
+       if (!text) return text;
+
+  // Remove any previous joiners/spaces we may have added (prevents double insertion)
+  const cleaned = text.replace(/[\u200B\u2060]/g, '');
+
+  // nbus / nnbus / ntrain / nnetwork -> n + WORD JOINER + bus/train/network
+  return cleaned.replace(/\bn+(bus|train|network)\b/gi, 'n\u2060$1');
     }
 
     // set current date to test for ticketFutureDate

--- a/src/app/controller/tickets.controller.js
+++ b/src/app/controller/tickets.controller.js
@@ -1763,11 +1763,11 @@
     function srPronunciation(text) {
        if (!text) return text;
 
-  // Remove any previous joiners/spaces we may have added (prevents double insertion)
-  const cleaned = text.replace(/[\u200B\u2060]/g, '');
-
-  // nbus / nnbus / ntrain / nnetwork -> n + WORD JOINER + bus/train/network
-  return cleaned.replace(/\bn+(bus|train|network)\b/gi, 'n\u2060$1');
+       // Remove any previous joiners/spaces we may have added (prevents double insertion)
+        const cleaned = text.replace(/[\u200B\u2060]/g, '');
+        
+        // nbus / nnbus / ntrain / nnetwork -> n + WORD JOINER + bus/train/network
+        return cleaned.replace(/\bn+(bus|train|network)\b/gi, 'n\u2060$1');
     }
 
     // set current date to test for ticketFutureDate

--- a/src/app/tickets/_tickets.scss
+++ b/src/app/tickets/_tickets.scss
@@ -139,10 +139,12 @@ a.icon-stylized-new:focus span:after {
   }
 
   .price {
+    p{
     font-weight: bold;
     margin-top: 10px;
     font-size: 18px;
-    line-height: 30px;
+    line-height: 30px;    
+  }
   }
 
   .event__date {

--- a/src/app/tickets/views/shared/item.html
+++ b/src/app/tickets/views/shared/item.html
@@ -16,8 +16,8 @@
   <div class="itemContent">
     <div class="grid-8">
       <a data-ng-href="$*baseUrl{{vm.finderLink}}#/ticket/{{ticket.id}}">
-        <h4 class="event__title">
-          {{ticket.name}}
+        <span class="event__title">
+          {{tickets.srPronunciation(ticket.name)}}
           <span class="payment-icons">
             <img
               ng-src="$*imgUrl/swift-logo.png"
@@ -34,7 +34,7 @@
               title="This ticket can be purchased on Direct Debit"
             />
           </span>
-        </h4>
+        </span>
       </a>
     </div>
     <div class="grid-4 modes">

--- a/src/app/tickets/views/shared/price.html
+++ b/src/app/tickets/views/shared/price.html
@@ -1,7 +1,12 @@
 <div class="grid-12">
-    <h5 class="price">
+    <div class="price">
         <span data-ng-if="ticket.swiftCurrentAmount < ticket.standardCurrentAmount">From {{(ticket.swiftCurrentAmount | currency:"£")}}</span>
-        <span data-ng-if="ticket.ticketCurrentAmount == ticket.standardCurrentAmount" data-ng-hide="ticket.swiftCurrentAmount < ticket.standardCurrentAmount">{{(ticket.standardCurrentAmount | currency:"£")}}</span>
+        <span data-ng-if="ticket.ticketCurrentAmount == ticket.standardCurrentAmount" data-ng-hide="ticket.swiftCurrentAmount < ticket.standardCurrentAmount">
+            <p>
+                {{(ticket.standardCurrentAmount | currency:"£")}} {{ tickets.getValiditySuffix(ticket)}}
+            </p>
+        </span>   
+        
         <span data-ng-if="ticket.standardDiscountCurrentAmount">
             <span class="discounted">{{(ticket.standardCurrentAmount | currency:"£")}}</span>&nbsp;
             <span>{{(ticket.standardDiscountCurrentAmount | currency:"£")}}</span>   
@@ -14,11 +19,11 @@
         <span data-ng-if="ticket.id == '811'">{{ticket.priceOverride}}</span>
         <span data-ng-if="ticket.ticketCurrentAmount && ticket.standardCurrentAmount == '0'">{{(ticket.ticketCurrentAmount | currency:"£")}}</span>
         <span data-ng-if="ticket.ticketCurrentAmount && !ticket.standardCurrentAmount">{{(ticket.ticketCurrentAmount | currency:"£")}}</span>
-        <span data-ng-if="ticket.validityId == 450930002" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> per month</span>
-        <span data-ng-if="ticket.validityId == 450930006" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> per month</span>
-        <span data-ng-if="ticket.validityId == 450930010" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> per month</span>
-        <span data-ng-if="ticket.validityId == 450930000" data-ng-hide="ticket.type == 'Carnet' || ticket.id == '811'"> a day</span>
-        <span data-ng-if="ticket.validityId == 450930001" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> a week</span>
-        <span data-ng-if="ticket.validityId == 450930003"> for 1 year</span>
-    </h5>
+        <!-- <span data-ng-if="ticket.validityId == 450930002" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> per month</span> -->
+        <!-- <span data-ng-if="ticket.validityId == 450930006" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> per month</span> -->
+        <!-- <span data-ng-if="ticket.validityId == 450930010" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> per month</span> -->
+        <!-- <span data-ng-if="ticket.validityId == 450930000" data-ng-hide="ticket.type == 'Carnet' || ticket.id == '811'"> a day</span> -->
+        <!-- <span data-ng-if="ticket.validityId == 450930001" data-ng-hide="ticket.ticketCurrentAmount && ticket.onlineCurrentAmount"> a week</span> -->
+        <!-- <span data-ng-if="ticket.validityId == 450930003"> for 1 year</span> -->
+    </div>
 </div>


### PR DESCRIPTION
### Issue identified

PR: https://github.com/west-midlands-ca/ticket-finder/issues/2

The ticket price was marked up as an <h5> heading, which is an incorrect use of heading semantics because the price is not a section heading.
As a result, screen readers treat the price as part of the page heading outline and announce it as:

- **“heading level 5 pound 20 dot 00 a week”**

This can confuse users and may be misinterpreted as £5.20 per week, especially when navigating via headings or listening at speed.
Related audit: **Headers skipped, missing or used incorrectly (1.3.1, 2.4.6, AA)**

Another Issue: A heading placed above the price (e.g. a week, per day) contains operator names such as nbus and ntrain, which are not announced by screen readers.
<img width="531" height="354" alt="image" src="https://github.com/user-attachments/assets/b8467500-2d2a-476f-adf6-f00b407561ec" />

### Fixes applied
✔ Replaced the <h5> price markup with non-heading semantic markup (price is no longer in the heading structure)
✔ Ensured the price + validity suffix (e.g. “a week / per month / for 1 year”) is announced as a single phrase
✔ Improved screen reader clarity by avoiding headings for non-heading content
✔ Incorrect heading usage above the price has been fixed, and operator names (e.g. nbus, ntrain) are now announced correctly by screen readers.

### Accessibility testing

✔ Tested with NVDA
✔ Verified the price is no longer announced as “heading level 5 …”
✔ Verified announcement is clear and continuous (e.g. “£20.00 a week”) without misleading interpretation